### PR TITLE
docs(README): update link to license file

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,4 +171,4 @@ This is a list of cases where unused dependencies were found using `poetry-udeps
 This tool is distributed under the terms of the Blue Oak license.
 Any contributions are licensed under the same license, and acknowledge via the [Developer Certificate of Origin](https://developercertificate.org/).
 
-See [LICENSE](LICENSE) for details.
+See [LICENSE](LICENSE.md) for details.


### PR DESCRIPTION
This patch updates a link to the `LICENSE.md` file which now has a markdown extension but did not previously.

Fixes: c7f71c5 ("docs(LICENSE): use `md` extension for nicer rendering")